### PR TITLE
Update instructions to correct 1.0.0 build method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Get the **core-site.xml** from the MapR environment, make the file readable by t
 ...
 <property> 
   <name>fs.defaultFS</name>
-  <value>maprfs://<cldbhost>:<port></value>
   <value>maprfs:///</value>
 </property>
 ...

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Get the **core-site.xml** from the MapR environment, make the file readable by t
 <property> 
   <name>fs.defaultFS</name>
   <value>maprfs://<cldbhost>:<port></value>
+  <value>maprfs:///</value>
 </property>
 ...
 ```

--- a/nifi-mapr-build.md
+++ b/nifi-mapr-build.md
@@ -1,5 +1,29 @@
 Build Full NiFi with MapR Dependencies
 ======================================
+
+## If using MapR > 1.0.0
+
+### Clone
+```
+git clone http://git-wip-us.apache.org/repos/asf/nifi.git
+git checkout -b 1.0.0 origin/rel/nifi-1.0.0
+```
+
+```
+cd nifi
+# assuming you are running 5.1 - otherwise check the docs for the appropriate version
+# for  mapr 4.0.2 use version : 2.5.1-mapr-1503
+mvn -T 2.0C clean install -DskipTests -Pmapr -Dhadoop.version=2.7.0-mapr-1602
+```
+
+### Deploy
+final build will be created at `nifi-assembly/target/nifi-0.x.0-SNAPSHOT-bin.zip`
+
+
+
+
+## If using NiFi < 1.0.0
+### Create MapR maven profile
 change your ~/.m2/settings.xml so that you have:
 
 ```xml
@@ -58,3 +82,4 @@ mvn -T 2.0C clean install -DskipTests -Pmapr -Dhadoop.version=2.5.1-mapr-1503
 
 ### Deploy
 final build will be created at `nifi-assembly/target/nifi-0.x.0-SNAPSHOT-bin.zip`
+


### PR DESCRIPTION
@xmlking there's no more need to create a .m2/settings or to remove the inotiy.

By the way, this is now documented at the NiFi wiki

https://cwiki.apache.org/confluence/display/NIFI/FAQs

Under section Processors
